### PR TITLE
Create a clickable area for a primary nav link

### DIFF
--- a/lib/stylesheets/patterns/_nav-primary.scss
+++ b/lib/stylesheets/patterns/_nav-primary.scss
@@ -11,7 +11,7 @@
 
   .rs-nav-link {
     line-height: 1em;
-    padding: 8px 0 2px 0;
+    padding: 8px 32px 2px 33px;
     color: $nav-primary-link;
     font-size: 18px;
     font-weight: 400;
@@ -29,7 +29,7 @@
     vertical-align: text-bottom;
     position: absolute;
     top: 50%;
-    right: -25px;
+    right: 12px;
     @include icon-sprite-position(caret-primary, 16px);
 
     &:before {
@@ -43,7 +43,6 @@
   }
 
   .rs-nav-item {
-    margin: 0 20px;
     border: 1px solid transparent;
 
     &:hover,
@@ -73,14 +72,9 @@
     }
 
     &.rs-dropdown {
-      padding-right: 25px;
-
       .rs-dropdown-menu {
-        margin-top: -2px;
-      }
-
-      &.active .rs-caret {
-        right: -25px;
+        margin: -2px 0 0 0px;
+        left: 32px;
       }
     }
 
@@ -111,6 +105,6 @@
   }
 
   & + .rs-nav {
-    padding-left: $nav-branding-width + 20px;
+    padding-left: $nav-branding-width + 7px;
   }
 }


### PR DESCRIPTION
Issue: Currently you can only click on the nav link text itself. It would be nice
if I would be able to click near the text and maintain the same behavior.

I know this is probably not the ideal solution below, but wanted to prompt some feedback.

What it currently looks like
![original](https://cloud.githubusercontent.com/assets/180066/5507888/7b9e8438-8775-11e4-95cf-dcfb5a6d264a.png)

What I want to happen
![original_goals](https://cloud.githubusercontent.com/assets/180066/5507918/9e463c4c-8775-11e4-8f15-da9e3c96cbd8.png)

With the changes in this PR
![new](https://cloud.githubusercontent.com/assets/180066/5507889/7d815ff0-8775-11e4-96ab-8a7824f2b929.png)

What I want for mycloud nav
![mycloud_change](https://cloud.githubusercontent.com/assets/180066/5507926/aec76ee2-8775-11e4-8fc1-c44ca04eaa23.png)

