### PR TITLE
Updated nav links area click

### DIFF
--- a/lib/stylesheets/patterns/_nav-primary.scss
+++ b/lib/stylesheets/patterns/_nav-primary.scss
@@ -11,7 +11,7 @@
 
   .rs-nav-link {
     line-height: 1em;
-    padding: 8px 32px 2px 33px;
+    padding: 8px 15px 2px 15px;
     color: $nav-primary-link;
     font-size: 18px;
     font-weight: 400;
@@ -44,6 +44,7 @@
 
   .rs-nav-item {
     border: 1px solid transparent;
+    margin: 0 5px;
 
     &:hover,
     &.hover {
@@ -72,9 +73,13 @@
     }
 
     &.rs-dropdown {
+      & > a,
+      .rs-nav-link {
+        padding-right: 35px;
+      }
       .rs-dropdown-menu {
         margin: -2px 0 0 0px;
-        left: 32px;
+        right: -15px;
       }
     }
 
@@ -105,6 +110,6 @@
   }
 
   & + .rs-nav {
-    padding-left: $nav-branding-width + 7px;
+    padding-left: $nav-branding-width + 20px;
   }
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/399776/7211593/27c2c10e-e511-11e4-90bc-e81881c07555.png)

![image](https://cloud.githubusercontent.com/assets/399776/7211798/a03b142c-e513-11e4-9f44-e929cff4def7.png)


originally from #134 

- old `li` click area is now the `a` or nav link item click area
- saves about 3px on each nav item due to some weird numbers we were using before.
