### PR TITLE
fix(bootstrap): correct font path for bootstrap-port

### DIFF
--- a/lib/stylesheets/canon-bootstrap/_fonts.scss
+++ b/lib/stylesheets/canon-bootstrap/_fonts.scss
@@ -3,11 +3,11 @@
   font-style: normal;
   font-weight: 600;
 
-  src: url('@{font-path}@{header-font-name}.eot');
-  src: url('@{font-path}@{header-font-name}.eot?#iefix') format('embedded-opentype'),
-       url('@{font-path}@{header-font-name}.woff') format('woff'),
-       url('@{font-path}@{header-font-name}.ttf') format('truetype'),
-       url('@{font-path}@{header-font-name}.svg#@{header-font-svg-id}') format('svg');
+  src: url($header-font-name+'.eot');
+  src: url($header-font-name+'.eot?#iefix') format('embedded-opentype'),
+       url($header-font-name+'.woff') format('woff'),
+       url($header-font-name+'.ttf') format('truetype'),
+       url($header-font-name+'.svg#'+$header-font-svg-id) format('svg');
 }
 
 @font-face {
@@ -15,9 +15,9 @@
   font-style: normal;
   font-weight: 400;
 
-  src: url('@{font-path}SourceSansPro-Regular-webfont.eot');
-  src: url('@{font-path}SourceSansPro-Regular-webfont.eot?#iefix') format('embedded-opentype'),
-  url('@{font-path}SourceSansPro-Regular-webfont.woff') format('woff'),
-  url('@{font-path}SourceSansPro-Regular-webfont.ttf') format('truetype'),
-  url('@{font-path}SourceSansPro-Regular-webfont.svg#@{header-font-svg-id}') format('svg');
+  src: url($header-font-name+'.eot');
+  src: url($header-font-name+'.eot?#iefix') format('embedded-opentype'),
+       url($header-font-name+'.woff') format('woff'),
+       url($header-font-name+'.ttf') format('truetype'),
+       url($header-font-name+'.svg#'+$header-font-svg-id) format('svg');
 }

--- a/lib/stylesheets/canon-bootstrap/_variables.scss
+++ b/lib/stylesheets/canon-bootstrap/_variables.scss
@@ -155,8 +155,5 @@ $dropdown-header-color: $gray;
 // CANON
 
 // fonts
-
-$font-path: '../../fonts/';
-$icon-font-path: $font-path;
 $header-font-name: 'SourceSansPro-Semibold-webfont';
 $header-font-svg-id: 'SourceSansProSemibold';


### PR DESCRIPTION
Fixes the font-path in the bootstrap port. 

It would incorrectly try to literally fetch `'@{font-path}@{header-font-name}.eot'`, etc.