### PR TITLE
Update bootstrap script to not bomb on current versions of Node

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -72,7 +72,7 @@ check_node_version () {
 
   version="$(node --version)"
 
-  if ! [[ "$version" =~ "v2" || "$version" =~ "v0.10" ]]; then
+  if [[ "$version" =~ ^v0\..\. ]]; then
     error "\nCanon requires Node 0.10.0 (or higher) or iojs 2.0.0 (or higher). Please update Node and try again.\n"
     exit 1
   fi


### PR DESCRIPTION
Warn only for node v0.?.*

Fixes #163
