### PR TITLE
fix(CNAME): removes cname file from docs

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-canon-ui.com


### PR DESCRIPTION
The doimain this CNAME points to expired and the site was no longer accessible.  Removing the file to fix the issue.