### PR TITLE
fix(CNAME): removes cname record from gh-pages branch

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-canon-ui.com


### PR DESCRIPTION
This is to fix the DNS issue created by the expiration of canon-ui.com