### PR TITLE
Gemfile.lock: update json to 1.8.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       redcarpet (~> 2.3.0)
       safe_yaml (~> 0.9.7)
       toml (~> 0.1.0)
-    json (1.7.7)
+    json (1.8.3)
     kramdown (1.3.1)
     liquid (2.5.5)
     listen (1.3.1)


### PR DESCRIPTION
This is necessary for compatibility with `ruby>=2.2.0`.

https://github.com/flori/json/issues/229
