### PR TITLE
Gemfile.lock: update rmagick to 2.13.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     redcarpet (2.3.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rmagick (2.13.2)
+    rmagick (2.13.3)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)


### PR DESCRIPTION
This is necessary for compatibility with HDRI ImageMagic builds.

https://github.com/rmagick-temp/rmagick/issues/18
