### PR TITLE
Gemfile.lock: update safe_yaml to 1.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     rspec-mocks (2.13.0)
     ruby-hmac (0.4.0)
     rubyzip (0.9.9)
-    safe_yaml (0.9.7)
+    safe_yaml (1.0.4)
     sauce (2.4.1)
       childprocess (>= 0.1.6)
       cmdparse (>= 2.0.2)


### PR DESCRIPTION
This is necessary for compatibility with `ruby>=2.2.0`

https://github.com/flori/json/issues/229
