### PR TITLE
package.json: update grunt-sass to 1.0.0

### DIFF
--- a/lib/stylesheets/canon/canon.scss
+++ b/lib/stylesheets/canon/canon.scss
@@ -1,4 +1,4 @@
-@import "normalize-scss/normalize";
+@import "normalize-scss/_normalize.scss";
 
 @import "settings";
 @import "mixins";

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "grunt-contrib-watch": "~0.5.2",
     "grunt-exec": "~0.4.6",
     "grunt-karma": "~0.6.1",
-    "grunt-sass": "^0.18.1",
+    "grunt-sass": "^1.0.0",
     "grunt-spritesmith": "^4.6.1",
     "jshint": "0.9.1"
   }


### PR DESCRIPTION
This is required to upgrade node-sass to 3.0.0, which is required to resolve libsass build issues on `nodejs>=0.12.0`.

indirectly relevant: https://github.com/sass/node-sass/issues/918
grunt-sass commit: https://github.com/sindresorhus/grunt-sass/commit/ad6f23a1729f115cc2402fa269aacc5ec7f13f9d (the exact issue where this was originally described is likely `sindresorhus/grunt-sass#196`, however they have disabled their issue tracker, so this is no longer available).
